### PR TITLE
Updating deprecated functions with Scipy.misc

### DIFF
--- a/measure.py
+++ b/measure.py
@@ -11,11 +11,13 @@
 import os
 import ntpath
 import numpy as np
+import skimage.transform
 from scipy import misc
 ## local libs
 from utils.data_utils import getPaths
 from utils.uiqm_utils import getUIQM
 from utils.ssm_psnr_utils import getSSIM, getPSNR
+
 
 # measurement in a common dimension
 im_w, im_h = 320, 240
@@ -43,7 +45,7 @@ def measure_UIQMs(dir_name, file_ext=None):
     uqims = []
     for img_path in paths:
         #print (paths)
-        im = misc.imresize(misc.imread(img_path), (im_h, im_w))
+        im = skimage.transform.resize(imageio.imread(img_path), (im_h, im_w))
         uqims.append(getUIQM(im))
     return np.array(uqims)
 
@@ -63,8 +65,8 @@ def measure_SSIM(GT_dir, Gen_dir):
         ## >> To evaluate only enhancement: use: 
         #gen_path = os.path.join(Gen_dir, name_split[0]+'_En.png') 
         if (gen_path in Gen_paths):
-            r_im = misc.imresize(misc.imread(img_path), (im_h, im_w))
-            g_im = misc.imresize(misc.imread(gen_path), (im_h, im_w))
+            r_im = skimage.transform.resize(imageio.imread(img_path), (im_h, im_w))
+            g_im = skimage.transform.resize(imageio.imread(gen_path), (im_h, im_w))
             assert (r_im.shape==g_im.shape), "The images should be of same-size"
             ssim = getSSIM(r_im, g_im)
             ssims.append(ssim)
@@ -87,8 +89,8 @@ def measure_PSNR(GT_dir, Gen_dir):
         ## >> To evaluate only enhancement: use: 
         #gen_path = os.path.join(Gen_dir, name_split[0]+'_En.png') 
         if (gen_path in Gen_paths):
-            r_im = misc.imresize(misc.imread(img_path, mode='L'), (im_h, im_w))
-            g_im = misc.imresize(misc.imread(gen_path, mode='L'), (im_h, im_w))
+            r_im = skimage.transform.resize(imageio.imread(img_path, mode='L'), (im_h, im_w))
+            g_im = skimage.transform.resize(imageio.imread(gen_path, mode='L'), (im_h, im_w))
             assert (r_im.shape==g_im.shape), "The images should be of same-size"
             psnr = getPSNR(r_im, g_im)
             psnrs.append(psnr)

--- a/test_sesr_Keras.py
+++ b/test_sesr_Keras.py
@@ -9,10 +9,9 @@ import os
 import time
 import ntpath
 import numpy as np
-from scipy import misc
+import skimage.transform
 import imageio
 from PIL import Image
-import skimage.transform
 from keras.models import model_from_json
 ## local libs
 from utils.data_utils import getPaths, preprocess, deprocess

--- a/test_sesr_Keras.py
+++ b/test_sesr_Keras.py
@@ -10,6 +10,9 @@ import time
 import ntpath
 import numpy as np
 from scipy import misc
+import imageio
+from PIL import Image
+import skimage.transform
 from keras.models import model_from_json
 ## local libs
 from utils.data_utils import getPaths, preprocess, deprocess
@@ -49,9 +52,10 @@ times = [];
 for img_path in test_paths:
     # prepare data
     img_name = ntpath.basename(img_path).split('.')[0]
-    img_lrd = misc.imread(img_path, mode='RGB').astype(np.float) 
+    img_lrd = imageio.imread(img_path, pilmode='RGB').astype(np.float)
+    #img_lrd = misc.imread(img_path, mode='RGB').astype(np.float) 
     inp_h, inp_w, _  =  img_lrd.shape # save the input im-shape
-    img_lrd = misc.imresize(img_lrd, (lr_height,lr_width))
+    img_lrd = skimage.transform.resize(img_lrd, (lr_height,lr_width))
     im = preprocess(img_lrd)
     im = np.expand_dims(im, axis=0)
     # generate enhanced image
@@ -68,14 +72,14 @@ for img_path in test_paths:
     # >> may add further post-processing for more informative map
     gen_mask[gen_mask<0.1] = 0 
     # reshape and save generated images for observation 
-    img_lrd = misc.imresize(img_lrd, (inp_h, inp_w))
-    gen_lr = misc.imresize(gen_lr, (inp_h, inp_w))
-    gen_mask = misc.imresize(gen_mask, (inp_h, inp_w))
-    gen_hr = misc.imresize(gen_hr, (inp_h*scale, inp_w*scale))
-    misc.imsave(os.path.join(samples_dir, img_name+'.png'), img_lrd)
-    misc.imsave(os.path.join(samples_dir, img_name+'_En.png'), gen_lr)
-    misc.imsave(os.path.join(samples_dir, img_name+'_Sal.png'), gen_mask)
-    misc.imsave(os.path.join(samples_dir, img_name+'_SESR.png'), gen_hr)
+    img_lrd = skimage.transform.resize(img_lrd, (inp_h, inp_w))
+    gen_lr = skimage.transform.resize(gen_lr, (inp_h, inp_w))
+    gen_mask = skimage.transform.resize(gen_mask, (inp_h, inp_w))
+    gen_hr = skimage.transform.resize(gen_hr, (inp_h*scale, inp_w*scale))
+    imageio.imsave(os.path.join(samples_dir, img_name+'.png'), img_lrd)
+    imageio.imsave(os.path.join(samples_dir, img_name+'_En.png'), gen_lr)
+    imageio.imsave(os.path.join(samples_dir, img_name+'_Sal.png'), gen_mask)
+    imageio.imsave(os.path.join(samples_dir, img_name+'_SESR.png'), gen_hr)
     print ("tested: {0}".format(img_path))
 
 # some statistics    

--- a/test_sesr_TF.py
+++ b/test_sesr_TF.py
@@ -10,8 +10,8 @@ import time
 import ntpath
 import numpy as np
 import tensorflow as tf
-from scipy import misc
 import skimage.transform
+from scipy import misc
 ## local libs
 from utils.data_utils import getPaths, preprocess, deprocess
 

--- a/test_sesr_TF.py
+++ b/test_sesr_TF.py
@@ -11,6 +11,7 @@ import ntpath
 import numpy as np
 import tensorflow as tf
 from scipy import misc
+import skimage.transform
 ## local libs
 from utils.data_utils import getPaths, preprocess, deprocess
 
@@ -81,9 +82,11 @@ times = [];
 for img_path in test_paths:
     # prepare data
     img_name = ntpath.basename(img_path).split('.')[0]
-    img_lrd = misc.imread(img_path, mode='RGB').astype(np.float)  
+    # updating deprecated scipy.imread with imageio
+    # https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imread.html
+    img_lrd = imageio.imread(img_path, pilmode='RGB').astype(np.float)  
     inp_h, inp_w, _  =  img_lrd.shape # save the input im-shape
-    img_lrd = misc.imresize(img_lrd, (lr_height,lr_width))
+    img_lrd = skimage.transform.resize(img_lrd, (lr_height,lr_width))
     im = preprocess(img_lrd)
     # generate enhanced image
     s = time.time()
@@ -98,14 +101,15 @@ for img_path in test_paths:
     # >> may add further post-processing for more informative map
     gen_mask[gen_mask<0.1] = 0 
     # reshape and save generated images for observation 
-    img_lrd = misc.imresize(img_lrd, (inp_h, inp_w))
-    gen_lr = misc.imresize(gen_lr, (inp_h, inp_w))
-    gen_mask = misc.imresize(gen_mask, (inp_h, inp_w))
-    gen_hr = misc.imresize(gen_hr, (inp_h*scale, inp_w*scale))
-    misc.imsave(os.path.join(samples_dir, img_name+'.png'), img_lrd)
-    misc.imsave(os.path.join(samples_dir, img_name+'_En.png'), gen_lr)
-    misc.imsave(os.path.join(samples_dir, img_name+'_Sal.png'), gen_mask)
-    misc.imsave(os.path.join(samples_dir, img_name+'_SESR.png'), gen_hr)
+    # Updating decremented misc.resize and misc.imsave with skimage.transform.resize and imageio.imsave
+    img_lrd = skimage.transform.resize(img_lrd, (inp_h, inp_w))
+    gen_lr = skimage.transform.resize(gen_lr, (inp_h, inp_w))
+    gen_mask = skimage.transform.resize(gen_mask, (inp_h, inp_w))
+    gen_hr = skimage.transform.resize(gen_hr, (inp_h*scale, inp_w*scale))
+    imageio.imsave(os.path.join(samples_dir, img_name+'.png'), img_lrd)
+    imageio.imsave(os.path.join(samples_dir, img_name+'_En.png'), gen_lr)
+    imageio.imsave(os.path.join(samples_dir, img_name+'_Sal.png'), gen_mask)
+    imageio.imsave(os.path.join(samples_dir, img_name+'_SESR.png'), gen_hr)
     print ("tested: {0}".format(img_path))
 
 # some statistics    

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -14,6 +14,7 @@ import numpy as np
 from PIL import Image
 from scipy import misc
 from glob import glob
+import skimage.transform
 
 def deprocess(x):
     # [-1,1] -> [0, 1]
@@ -35,8 +36,8 @@ def getPaths(data_dir):
     return np.asarray(image_paths)
 
 def read_and_resize(paths, res=(480, 640), mode_='RGB'):
-    img = misc.imread(paths, mode=mode_).astype(np.float)
-    img = misc.imresize(img, res)
+    img = imageio.imread(paths, pilmode=mode_).astype(np.float)
+    img = skimage.transform.resize(img, res)
     return img
 
 def preprocess_mask(x):


### PR DESCRIPTION
Following the documentation, the following functions in scipy.misc have been deprecated. I've replaced them with the recommended functions to avoid encountering errors. The deprecated functions are:

scipy.misc.imread (deprecated in 1.0.0, removed in 1.2.0) -> imageio.imread()
scipy.misc.imresize(deprecated in 1.0.0 removed in 1.3.0) -> skimage.transform.resize()
scipy.misc.imsave(deprecated in 1.0.0 removed in 1.2.0) -> imageio.imsave()

https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imread.html
https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imresize.html
